### PR TITLE
Handle POST submissions in addition to GET

### DIFF
--- a/src/MODXRevolutionValetDriver.php
+++ b/src/MODXRevolutionValetDriver.php
@@ -76,7 +76,7 @@ class MODXRevolutionValetDriver extends BasicValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        if ($_SERVER['REQUEST_METHOD'] === 'GET' || $_SERVER['REQUEST_METHOD'] === 'POST') {
             $requestParameter = ltrim($uri, '/');
             if ($requestParameter !== '') {
                 $requestParameterParts = explode('/', $requestParameter, 2);
@@ -87,14 +87,25 @@ class MODXRevolutionValetDriver extends BasicValetDriver
                     if (in_array($requestParameterCultureKeyPart, $this->_getAvailableCultureKeys())) {
                         $requestParameterQueryPart = $requestParameterParts[1];
 
-                        $_GET['cultureKey'] = $requestParameterCultureKeyPart;
+                        $cultureKey = $requestParameterCultureKeyPart;
                         // If the requestParameter contains a cultureKey we don't need it in the query
                         $requestParameter = $requestParameterQueryPart;
                     }
                 }
 
-                $_GET['q'] = $requestParameter;
-                $_REQUEST += $_GET;
+                if($_SERVER['REQUEST_METHOD'] === 'GET') {
+                    if(isset($cultureKey)) {
+                        $_GET['cultureKey'] = $cultureKey;
+                    }
+                    $_GET['q'] = $requestParameter;
+                    $_REQUEST += $_GET;
+                } else {
+                    if(isset($cultureKey)) {
+                        $_POST['cultureKey'] = $cultureKey;
+                    }
+                    $_POST['q'] = $requestParameter;
+                    $_REQUEST += $_POST;
+                }
             }
         }
 


### PR DESCRIPTION
The previous version of this driver only set a 'q' path in the GET variable if the REQUEST_METHOD was GET. This update also checks for POST submission and sets the same variables in the POST variable as would be set in the GET.